### PR TITLE
[APS-19259..APS-19266] fix: bump selenium-java, browserstack-local-java, surefire to drop 8 vulnerable transitive deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
         <junit-jupiter-engine>5.8.1</junit-jupiter-engine>
         <junit-vintage-engine>5.4.0</junit-vintage-engine>
         <json-simple>1.1</json-simple>
-        <selenium-java>4.1.0</selenium-java>
-        <maven-surefire-plugin>3.0.0-M5</maven-surefire-plugin>
-        <browserstack-local-java>1.0.6</browserstack-local-java>
+        <selenium-java>4.33.0</selenium-java>
+        <maven-surefire-plugin>3.5.3</maven-surefire-plugin>
+        <browserstack-local-java>1.1.6</browserstack-local-java>
         <httpclient>4.5.13</httpclient>
         <parallel.count>3</parallel.count>
         <tests.sample>**/tests.SampleTest.java</tests.sample>
@@ -114,7 +114,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
+                        <version>3.5.3</version>
                         <configuration>
                             <includes>
                                 <include>${tests.local}</include>
@@ -135,7 +135,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
+                        <version>3.5.3</version>
                         <configuration>
                             <includes>
                                 <include>${tests.sample}</include>


### PR DESCRIPTION
## Issue
Eight security advisories flagged against transitive dependencies resolved from `pom.xml`. None of the flagged artifacts are direct dependencies — they all arrive via 3 outdated direct deps.

## Root Cause (`mvn dependency:tree` on `main`)

| Jira | Vulnerable artifact (version on `main`) | Advisory | CVSS | Pulled in by |
|---|---|---|---|---|
| `jackson-core` 2.13.0 | [GHSA-h46c-h94j-95f3](https://github.com/advisories/GHSA-h46c-h94j-95f3) | – | `selenium-java:4.1.0` → `selenium-remote-driver` → `opentelemetry-exporter-logging:1.9.0` → `opentelemetry-sdk-logs` |
| `jackson-databind` 2.13.0 | [GHSA-57j2-w4cx-62h2](https://github.com/advisories/GHSA-57j2-w4cx-62h2) | 7.5 | same path as above |
| `io.netty:netty-codec` 4.1.69.Final | [GHSA-mj4r-2hfc-f8p6](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6) | 7.5 | `selenium-java:4.1.0` → `selenium-remote-driver` |
| `io.netty:netty-codec-http` 4.1.69.Final | [GHSA-pwqr-wmgm-9rr8](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8) | 7.5 | `selenium-java:4.1.0` → `selenium-remote-driver` |
| `io.netty:netty-transport-native-epoll` 4.1.69/4.1.60 | [GHSA-rwm7-x88c-3g2p](https://github.com/advisories/GHSA-rwm7-x88c-3g2p) | 7.5 | `selenium-java:4.1.0` → `selenium-remote-driver` (also via `async-http-client`) |
| `maven-shared-utils` 3.1.0 | [GHSA-rhgr-952r-6p8q](https://github.com/advisories/GHSA-rhgr-952r-6p8q) | **9.8** | `maven-surefire-plugin:3.0.0-M5` (declared as dependency) → `maven-surefire-common` → `maven-artifact-transfer:0.11.0` |
| `async-http-client` 2.12.3 | [GHSA-mfj5-cf8g-g2fv](https://github.com/advisories/GHSA-mfj5-cf8g-g2fv) | – | `selenium-java:4.1.0` → `selenium-remote-driver` |
| `org.json:json` 20160212 | [GHSA-3vqj-43w4-2q58](https://github.com/advisories/GHSA-3vqj-43w4-2q58) | 7.5 | `browserstack-local-java:1.0.6` |

## Fix Applied
Three direct-dependency bumps, no code changes (no source file imports Selenium; SDK/playwright already resolve `LATEST`):

| Direct dependency | Before | After | Effect on flagged artifacts |
|---|---|---|---|
| `selenium-java` | 4.1.0 | 4.33.0 | `io.netty:*`, `org.asynchttpclient:*`, `com.fasterxml.jackson.core:*` **removed entirely** from the tree (fixes 6 of 8 tickets) |
| `browserstack-local-java` | 1.0.6 | 1.1.6 | `org.json:json` → **20231013** (≥ patched 20230227) |
| `maven-surefire-plugin` | 3.0.0-M5 | 3.5.3 | `org.apache.maven.shared:maven-shared-utils` **removed** (surefire now uses its own shaded `surefire-shared-utils:3.5.3`) |

Verified with `mvn dependency:tree` on this branch: no `io.netty:*`, no `org.asynchttpclient:*`, no `com.fasterxml.jackson.core:*`, no `org.apache.maven.shared:maven-shared-utils`; `org.json:json:20231013`.

## Relationship to other PRs
- #8 only pins `playwright` to 1.52.0 and addresses none of these advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)